### PR TITLE
Set middleware type to NATIVE as default

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -3,8 +3,8 @@
 ## Python
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
-|types-requests|2.31.0.20240125|Apache 2.0|
-|urllib3|2.2.0|MIT|
+|types-requests|2.31.0.20240311|Apache 2.0|
+|urllib3|2.2.1|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/velocitas_lib/middleware.py
+++ b/velocitas_lib/middleware.py
@@ -24,4 +24,4 @@ class MiddlewareType(Enum):
 
 def get_middleware_type() -> MiddlewareType:
     """Return the current middleware type."""
-    return MiddlewareType.DAPR
+    return MiddlewareType.NATIVE


### PR DESCRIPTION
Set the middleware type to NATIVE by default.
At the moment this is relevant for the local runtime, only.