### PR TITLE
Feature add runnable service

### DIFF
--- a/velocitas_lib/services.py
+++ b/velocitas_lib/services.py
@@ -84,6 +84,7 @@ def parse_service_config(
     """
 
     is_enabled = True
+    is_runnable = True
     container_image = None
     env_vars = dict[str, Optional[str]]()
     ports = []

--- a/velocitas_lib/services.py
+++ b/velocitas_lib/services.py
@@ -186,13 +186,13 @@ def get_services(verbose: bool = True, get_runnable: bool = False) -> List[Servi
     return services
 
 
-def get_specific_service(service_id: str) -> Service:
+def get_specific_service(service_id: str, get_runnable: bool = False) -> Service:
     """Return the specified service as Python object.
 
     Args:
         service_id: The ID of the service to be parsed.
     """
-    services = get_services(get_runnable=True)
+    services = get_services(get_runnable=get_runnable)
     services = list(filter(lambda service: service.id == service_id, services))
     if len(services) == 0:
         raise RuntimeError(f"Service with id '{service_id}' not defined")


### PR DESCRIPTION
That something like `velocitas exec runtime-local runservice <service-id>` is doable. We do not want to start the service at during runtime up because we maybe not need it then. Second one would be to have a interactive client come up in a separate terminal.

In the runtime.json you would then specify:
```
 {
                "key": "runnable",
                "value": "true"
            },
```